### PR TITLE
Shortcode atts on cb_calendar that are arrays take input as comma separated list

### DIFF
--- a/includes/CB_Shortcodes.php
+++ b/includes/CB_Shortcodes.php
@@ -22,6 +22,24 @@ class CB_Shortcodes extends CB_Object {
 	 * @param array $atts
 	 */
 	public function calendar_shortcode ( $atts ) {
+		/*
+		These fields pass in a single value or a list of comma separated values. They need to be converted to an array before merging with the default args.
+		*/
+
+		$array_atts_fields = array(
+			'timeframe_id',
+			'owner_id',
+			'location_id',
+			'item_id',
+			'location_cat',
+			'item_cat'
+		);
+
+		foreach($array_atts_fields as $field) {
+			if (isset($atts[$field])) {
+				$atts[$field] = explode(',', $atts[$field]);
+			}
+		}
 
 		$args = shortcode_atts( $this->default_query_args, $atts, 'cb_calendar' );
 

--- a/templates/calendar-timeframes.php
+++ b/templates/calendar-timeframes.php
@@ -14,23 +14,27 @@
 <?php	$cal = $template_args;
 	if ( !empty ( $cal )) { ?>
 		<?php // calendar ?>
+		<div class="cb-calendar">
 			<ul class="cb-calendar">
+				<?php // print_r($cal) ;?>
 				<?php if ( is_array( $cal['calendar'] )) { ?>
 					<?php foreach ( $cal['calendar'] as $cal_date => $date ) { ?>
 						<li class="cb-date weekday_<?php echo date ( 'w', strtotime( $cal_date ) );  ?>" id="<?php echo $cal_date; ?>">
 							<span class="cb-holiday"><?php echo $date['holiday']; ?></span>
 							<span class="cb-M"><?php echo date ( 'M', strtotime( $cal_date ) );  ?></span>
 							<span class="cb-j"><?php echo date ( 'j', strtotime( $cal_date ) );  ?></span>
-									<ul class="cb-slots"></span>
+								<?php if (is_array($date['slots'])) { ?>
+									<ul class="cb-slots">
 										<?php foreach ( $date['slots'] as $slot ) { ?>
 											<li id="<?php echo $slot['slot_id']; ?>" class="cb-slot" alt="<?php echo esc_html( $slot['description'] ); ?>" <?php echo CB_Gui::slot_attributes( $slot ); ?>>
 												<!-- checkbox or similar here -->
 											</li>
 										<?php } // endforeach $slots ?>
 									</ul>
-							</li><? // end li.cb-date ?>
+								<?php } ?>
+							</li><?php // end li.cb-date ?>
 					<?php } // endforeach $cal ?>
 				<?php } //if ( is_array( $cal['calendar'] ))  ?>
-			</ul><? // end ul.cb-calendar ?>
-	</div> <? // end div.cb-calendar ?>
+			</ul><?php // end ul.cb-calendar ?>
+	</div> <?php // end div.cb-calendar ?>
 <?php } //if ( is_array( $calendar )) ?>


### PR DESCRIPTION
E.g. [cb_calendar item_id="24,32"]

Affects these fields:
'timeframe_id',
'owner_id',
'location_id',
'item_id',
'location_cat',
'item_cat'